### PR TITLE
Use linear ramps between volume changes

### DIFF
--- a/backend/jack_backend.cpp
+++ b/backend/jack_backend.cpp
@@ -102,11 +102,15 @@ bool JackBackend::renameInput(const QString old_name, const QString new_name) {
 	if (done_it) { // Maintain the volume maps
 		if (involumes.contains(old_name)) {
 			involumes.insert(new_name, involumes[old_name]);
+			involumes_new.insert( new_name, involumes_new[ old_name ] );
 			involumes.remove(old_name);
+			involumes_new.remove(old_name);
 		}
 		if (volumes.contains(old_name)) {
 			volumes.insert(new_name, volumes[old_name]);
+			volumes_new.insert( new_name, volumes[ old_name ] );
 			volumes.remove(old_name);
+			volumes_new.remove( old_name );
 		}
 	}
 	
@@ -121,14 +125,18 @@ bool JackBackend::renameOutput(const QString old_name, const QString new_name) {
 	if (done_it) {
 		if (outvolumes.contains(old_name)) {
 			outvolumes.insert(new_name, outvolumes[old_name]);
+			outvolumes_new.insert( new_name, outvolumes[ old_name ] );
 			outvolumes.remove(old_name);
+			outvolumes_new.remove( old_name );
 		}
 		QStringListIterator ipi(in_ports_list);
 		while(ipi.hasNext()) {
 			QString input(ipi.next());
 			if (volumes[input].contains(old_name)) {
 				volumes[input].insert(new_name, volumes[input][old_name]);
+				volumes_new[ input ].insert( new_name, volumes[ input ][ old_name ] );
 				volumes[input].remove(old_name);
+				volumes_new[ input ].remove( old_name );
 			}
 		}
 	}
@@ -176,6 +184,17 @@ void JackBackend::setVolume( QString channel, QString output, float volume ) {
 		volumes[ channel ][ output ] = volume;
 }
 
+void JackBackend::setVolumeNew(QString channel, QString output, float volume) {
+	//qDebug() << "JackBackend::setVolumeNew( " << channel << ", " << output << ", " << volume << " )";
+	if ( channel == output ) {
+		if ( involumes_new.contains( channel ) )
+			setInVolumeNew( channel, volume );
+		else
+			setOutVolumeNew( channel, volume );
+	} else
+		volumes_new[ channel ][ output ] = volume;
+}
+
 float JackBackend::getVolume( QString channel, QString output ) {
 	//qDebug() << "JackBackend::getVolume( " << channel << ", " << output << " ) = " << volumes[ channel ][ output ];
 	if ( channel == output ) {
@@ -193,10 +212,38 @@ float JackBackend::getVolume( QString channel, QString output ) {
 	return 0;
 }
 
+float JackBackend::getVolumeNew(QString channel, QString output) {
+	//qDebug() << "JackBackend::getVolumeNew( " << channel << ", " << output << " ) = " << volumes[ channel ][ output ];
+	if ( channel == output ) {
+		if ( outvolumes_new.contains( channel ) )
+			return getOutVolumeNew( channel );
+		if ( involumes_new.contains( channel ) )
+			return getInVolumeNew( channel );
+	} else {
+		//if ( !volumes.contains( channel ) )
+		//	volumes.insert( channel, QMap<QString,float> );
+		if ( !volumes_new[ channel ].contains( output ) ) {
+			if ( volumes[ channel ].contains( output ) ) {
+				volumes_new[ channel ].insert( output, volumes[ channel ][ output ]);
+			} else {
+				volumes_new[ channel ].insert( output, 0 );
+			}
+		}
+		return volumes_new[ channel ][ output ];
+	}
+	return 0;
+}
+
 void JackBackend::setOutVolume( QString ch, float n ) {
 	//qDebug() << "JackBackend::setOutVolume(QString " << ch << ", float " << n << " )";
 	outvolumes[ ch ] = n;
 }
+
+void JackBackend::setOutVolumeNew( QString ch, float n ) {
+	//qDebug() << "JackBackend::setOutVolumeNew(QString " << ch << ", float " << n << " )";
+	outvolumes_new[ ch ] = n;
+}
+
 float JackBackend::getOutVolume( QString ch ) {
 	//qDebug() << "JackBackend::getOutVolume(QString " << ch << " )";
 	//outvolumes.insert( ch, 1 );
@@ -204,16 +251,43 @@ float JackBackend::getOutVolume( QString ch ) {
 		outvolumes.insert( ch, 1 );
 	return outvolumes[ ch ];
 }
+
+float JackBackend::getOutVolumeNew( QString ch ) {
+	//qDebug() << "JackBackend::getOutVolumeNew(QString " << ch << " )";
+	if ( !outvolumes_new.contains( ch ) )
+		outvolumes_new.insert( ch, 1 );
+	return outvolumes_new[ ch ];
+}
+
 void JackBackend::setInVolume( QString ch, float n ) {
 	//qDebug() << "JackBackend::setInVolume(QString " << ch << ", float " << n << " )";
 	involumes[ ch ] = n;
 }
+
+void JackBackend::setInVolumeNew(QString ch , float n) {
+	//qDebug() << "JackBackend::setInVolumeNew(QString " << ch << ", float " << n << " )";
+	involumes_new[ ch ] = n;
+}
+
 float JackBackend::getInVolume( QString ch ) {
 	//qDebug() << "JackBackend::getInVolume(QString " << ch << " )";
 	//involumes.insert( ch, 1 );
 	if ( !involumes.contains( ch ) )
 		involumes.insert( ch, 1 );
 	return involumes[ ch ];
+}
+
+float JackBackend::getInVolumeNew(QString ch) {
+	//qDebug() << "JackBackend::getInVolumeNew(QString " << ch << " )";
+	//involumes.insert( ch, 1 );
+	if ( !involumes_new.contains( ch ) ) {
+		if ( involumes.contains( ch ) ) {
+			involumes_new.insert( ch, involumes[ ch ] );
+		} else {
+			involumes_new.insert( ch, 1 );
+		}
+	}
+	return involumes_new[ ch ];
 }
 
 void JackBackend::send_signal(const ::jack_midi_data_t b1,
@@ -226,6 +300,7 @@ int JackMix::process( jack_nframes_t nframes, void* arg ) {
 	//qDebug() << "JackMix::process( jack_nframes_t " << nframes << ", void* )";
 	JackMix::JackBackend* backend = static_cast<JackMix::JackBackend*>( arg );
 
+	float threshold = 0.0000001;
 	// Deal with MIDI events
 	void* midi_buffer { ::jack_port_get_buffer(backend->midi_port, nframes) };
 	::jack_midi_event_t event;
@@ -253,40 +328,74 @@ int JackMix::process( jack_nframes_t nframes, void* arg ) {
 	}
 	/// Adjust inlevels.
 	for ( in_it = backend->in_ports.begin(); in_it != backend->in_ports.end(); ++in_it ) {
-                QString key {in_it.key()};
-		jack_default_audio_sample_t* tmp = ins[key];
-		float volume = backend->getInVolume(key);
-                float max {0};
-		for ( jack_nframes_t n=0; n<nframes; n++ ) {
-                        tmp[ n ] *= volume;
-                        max = qMax(max, static_cast<float>(tmp[n]));
-                }
-                backend->newInputLevel(key, max);
+		QString key {in_it.key()};
+		jack_default_audio_sample_t* tmp = ins[ key ];
+		float volume = backend->getInVolume( key );
+		float volume_new = backend->getInVolumeNew( key );
+		float max {0};
+		if ( qFabs( ( volume_new - volume ) / volume ) > threshold) {
+			for ( jack_nframes_t n=0; n<nframes; n++ ) {
+				tmp[ n ] *=	volume + n * ( volume_new - volume ) / nframes;
+				max = qMax( max, static_cast<float>( tmp[ n ] ) );
+			}
+		} else {
+			for ( jack_nframes_t n=0; n<nframes; n++) {
+				tmp[ n ] *= volume_new;
+				max = qMax( max, static_cast<float>( tmp[ n ] ) );
+			}
+		}
+		backend->newInputLevel( key, max );
+		if ( volume_new != volume ) {
+			backend->setInVolume( key, volume_new );
+		}
 	}
+		 
 	/// The actual mixing.
 	for ( in_it = backend->in_ports.begin(); in_it != backend->in_ports.end(); ++in_it ) {
 		jack_default_audio_sample_t* tmpin = ins[ in_it.key() ];
 		for ( out_it = backend->out_ports.begin(); out_it != backend->out_ports.end(); ++out_it ) {
 			jack_default_audio_sample_t* tmpout = outs[ out_it.key() ];
-			float tmpvolume = backend->getVolume( in_it.key(), out_it.key() );
-			for ( jack_nframes_t n=0; n<nframes; n++ ) {
-				tmpout[ n ] += tmpin[ n ] * tmpvolume;
+			float volume = backend->getVolume( in_it.key(), out_it.key() );
+			float volume_new = backend->getVolumeNew( in_it.key(), out_it.key() );
+			if ( qFabs( ( volume_new - volume ) / volume ) > threshold ) {
+				for ( jack_nframes_t n=0; n<nframes; ++n ) {
+					tmpout[ n ] += tmpin[ n ] * ( volume + n * (volume_new - volume) / nframes );
+				}
+			} else {
+				for ( jack_nframes_t n=0; n<nframes; n++ ) {
+					tmpout[ n ] += tmpin[ n ] * volume_new;
+				}
+			}
+			if ( volume != volume_new) {
+				backend->setVolume( in_it.key(), out_it.key(), volume_new);
 			}
 		}
 	}
 	/// Adjust outlevels.
 	for ( out_it = backend->out_ports.begin(); out_it != backend->out_ports.end(); ++out_it ) {
-                QString key {out_it.key()};
+		QString key {out_it.key()};
 		jack_default_audio_sample_t* tmp = outs[ key ];
 		float volume = backend->getOutVolume( key );
-                float max {0};
-		for ( jack_nframes_t n=0; n<nframes; n++ ) {
-                        tmp[ n ] *= volume;
-                        max = qMax(max, static_cast<float>(tmp[n]));
-                }
-                backend->newOutputLevel(key, max);
+		float volume_new = backend->getOutVolumeNew( key );
+		float max {0};
+		if ( qFabs( ( volume_new - volume ) / volume ) > threshold ) {
+			qDebug() << "BIG CHANGE";
+			for ( jack_nframes_t n=0; n<nframes; n++ ) {
+				tmp[ n ] *=	volume + n * ( volume_new - volume ) / nframes;
+				max = qMax( max, static_cast<float>( tmp[ n ] ) );
+			}
+		} else {
+			for ( jack_nframes_t n=0; n<nframes; n++ ) {
+				tmp[ n ] *= volume;
+				max = qMax( max, static_cast<float>( tmp[ n ] ) );
+			}
+		}
+		backend->newOutputLevel(key, max);
+		if ( volume_new != volume ) {
+			backend->setOutVolume( key, volume_new );
+		}
 	}
-	
+
 	// Send any information about channel levels
 	backend->report();
         

--- a/backend/jack_backend.h
+++ b/backend/jack_backend.h
@@ -23,6 +23,7 @@
 #ifndef JACKMIX_JACK_BACKEND_H
 #define JACKMIX_JACK_BACKEND_H
 
+#include <QtCore/QtMath>
 #include <QtCore/QMap>
 #include <QtCore/QHash>
 #include <QtCore/QString>
@@ -74,14 +75,20 @@ public:
 	
 	/// sets the volume of channel,output
 	void setVolume( QString,QString,float );
+	void setVolumeNew( QString,QString,float );
 	/// returns the volume of channel,output
 	float getVolume( QString,QString );
+	float getVolumeNew ( QString,QString );
 	
 private:
 	void setOutVolume( QString, float );
+	void setOutVolumeNew( QString, float );
 	float getOutVolume( QString );
+	float getOutVolumeNew( QString );
 	void setInVolume( QString, float );
+	void setInVolumeNew( QString,float );
 	float getInVolume( QString );
+	float getInVolumeNew( QString );
 	bool rename(portsmap &map, QStringList &lst, const QString old_name, const char *new_name);
 public:
 	/// returns a QStringList with the names of the out-channels
@@ -103,8 +110,11 @@ private:
 	::jack_client_t *client;
 	/// First dimension is input-channels, second is output-channels
 	QMap<QString,QMap<QString,float> > volumes;
+	QMap<QString,QMap<QString,float> > volumes_new;
 	QHash<QString,float> outvolumes;
+	QHash<QString,float> outvolumes_new;
 	QHash<QString,float> involumes;
+	QHash<QString,float> involumes_new;
 	
 	/// Process the second and third bytes of the MIDI CC message
 	/// (the JACK process() routine can't do this because it's not a QObject

--- a/jackmix/mainwindow.cpp
+++ b/jackmix/mainwindow.cpp
@@ -263,7 +263,7 @@ void MainWindow::openFile( QString path ) {
 				QString volume = in.attribute( "volume" );
 				QString midi = in.attribute( "midi" );
 				addInput( name );
-				_backend->setVolume( name, name, volume.toDouble() );
+				_backend->setVolumeNew( name, name, volume.toDouble() );
 				// Input gain elements have the same name for input and output
 				_inputmps[QString("%1,%1").arg(name)] = midi;
 				
@@ -275,7 +275,7 @@ void MainWindow::openFile( QString path ) {
 				QString volume = out.attribute( "volume" );
 				QString midi = out.attribute("midi");
 				addOutput( name );
-				_backend->setVolume( name, name, volume.toDouble() );
+				_backend->setVolumeNew( name, name, volume.toDouble() );
 				// Output gain elements have the same name for input and output
 				_outputmps[QString("%1,%1").arg(name)] = midi;
 			}
@@ -286,7 +286,7 @@ void MainWindow::openFile( QString path ) {
 				QString out = volume.attribute( "out" );
 				QString value = volume.attribute( "value" );
 				QString midi = volume.attribute( "midi" );
-				_backend->setVolume( in, out, value.toDouble() );
+				_backend->setVolumeNew( in, out, value.toDouble() );
 				if (!midi.isEmpty()) _mixermps[QString("%1,%2").arg(in, out)] = midi;
 			}
 

--- a/libcore/backend_interface.h
+++ b/libcore/backend_interface.h
@@ -55,12 +55,15 @@ Q_OBJECT
 		/**
 		 * @brief Set the volume of the named node.
 		 */
+		virtual void setVolumeNew( QString, QString, float ) =0;
+		/**
+		 * @brief Set the volume of the named node.
+		 */
 		virtual void setVolume( QString, QString, float ) =0;
 		/**
 		 * @brief Get the volume of the named node.
 		 */
 		virtual float getVolume( QString, QString ) =0;
-
 		/**
 		 * @brief Add a channel and return true on success.
 		 *

--- a/libelements/aux_elements.cpp
+++ b/libelements/aux_elements.cpp
@@ -116,7 +116,7 @@ AuxElement::~AuxElement() {
 }
 
 void AuxElement::emitvalue( double n ) {
-	backend()->setVolume( _in[0], _out[0], dbtoamp( n ) );
+	backend()->setVolumeNew( _in[0], _out[0], dbtoamp( n ) );
 }
 
 void AuxElement::setIndicator(const QColor& c) { _poti->setIndicatorColor(c); };

--- a/libelements/stereo_elements.cpp
+++ b/libelements/stereo_elements.cpp
@@ -92,7 +92,7 @@ Mono2StereoElement::Mono2StereoElement( QStringList inchannel, QStringList outch
 	QVBoxLayout* _layout = new QVBoxLayout( this );
 	_layout->setMargin( 0 );
 	_layout->setSpacing( 0 );
-
+  
 	menu()->addAction( "Select", this, SLOT( slot_simple_select() ) );
 	menu()->addAction( "Replace", this, SLOT( slot_simple_replace() ) );
         menu()->addAction( "Explode", this, SLOT( slot_simple_explode() ) );
@@ -154,8 +154,8 @@ void Mono2StereoElement::calculateVolumes() {
 		left = dbtoamp( _volume_value )*( 1-_balance_value );
 	if ( _balance_value < 0 )
 		right = dbtoamp( _volume_value )*( 1+_balance_value );
-	backend()->setVolume( _in[0], _out[0], left );
-	backend()->setVolume( _in[0], _out[1], right );
+	backend()->setVolumeNew( _in[0], _out[0], left );
+	backend()->setVolumeNew( _in[0], _out[1], right );
 }
 
 
@@ -167,8 +167,8 @@ Stereo2StereoElement::Stereo2StereoElement( QStringList inchannels, QStringList 
 	, _balance_value( 0 )
 	, _volume_value( 0 )
 {
-	backend()->setVolume( _in[0], _out[1], 0 );
-	backend()->setVolume( _in[1], _out[0], 0 );
+	backend()->setVolumeNew( _in[0], _out[1], 0 );
+	backend()->setVolumeNew( _in[1], _out[0], 0 );
 	double left = backend()->getVolume( _in[0], _out[0] );
 	double right = backend()->getVolume( _in[1], _out[1] );
 	if ( left>right )
@@ -253,6 +253,6 @@ void Stereo2StereoElement::calculateVolumes() {
 		left = dbtoamp( _volume_value )*( 1-_balance_value );
 	if ( _balance_value < 0 )
 		right = dbtoamp( _volume_value )*( 1+_balance_value );
-	backend()->setVolume( _in[0], _out[0], left );
-	backend()->setVolume( _in[1], _out[1], right );
+	backend()->setVolumeNew( _in[0], _out[0], left );
+	backend()->setVolumeNew( _in[1], _out[1], right );
 }


### PR DESCRIPTION
Linear ramping between volume changes over the course of an audio buffer's worth of samples.  If buffer is too small (not sure how small is too small) this implementation can still lead to pops, but it does a good job at 256 samples at 48kHz sampling rate. 