### PR TITLE
Add slider elements

### DIFF
--- a/jackmix/mainwindow.cpp
+++ b/jackmix/mainwindow.cpp
@@ -298,7 +298,7 @@ void MainWindow::openFile( QString path ) {
 				QStringList outs;
 				for ( QDomElement out = element.firstChildElement( "out" ); !out.isNull(); out = out.nextSiblingElement( "out" ) )
 					outs << out.attribute( "name" );
-				_mixerwidget->createControl( ins, outs );
+				_mixerwidget->createControl( ins, outs);
 				// Just one set of midi control parameters for the whole saved element
 				_mixermps[QString("%1,%2").arg(ins[0], outs[0])] = element.attribute("midi");
 

--- a/libelements/aux_elements.cpp
+++ b/libelements/aux_elements.cpp
@@ -25,6 +25,7 @@
 #include "aux_elements.moc"
 
 #include "knob.h"
+#include "slider.h"
 #include "midicontrolchannelassigner.h"
 
 #include <QtWidgets/QLayout>
@@ -56,14 +57,17 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"AuxElement";
 	}
-	QStringList canCreate( int in, int out ) const {
-		if ( in==1 && out==1 ) return QStringList()<<"AuxElement";
+	QStringList canCreate( int in, int out, int state = 0 ) const {
+		if ( in==1 && out==1 && state==0) return QStringList()<<"AuxElement";
+		if ( in==1 && out==1 && state==1) return QStringList()<<"AuxElementSlider";
 		return QStringList();
 	}
 
 	Element* create( QString type , QStringList ins, QStringList outs, Widget* p, const char* n=0 ) {
 		if ( type=="AuxElement" )
 			return new AuxElement( ins, outs, p, n );
+		if ( type=="AuxElementSlider" )
+			return new AuxElementSlider( ins, outs, p, n );
 		else
 			return 0;
 	}
@@ -74,7 +78,7 @@ void MixerElements::init_aux_elements() {
 }
 
 AuxElement::AuxElement( QStringList inchannel, QStringList outchannel, MixingMatrix::Widget* p, const char* n )
-	: Element( inchannel, outchannel, p, n )
+	: Element( inchannel, outchannel, p,"AuxElement", n )
 	, dB2VolCalc( -42, 6 )
 {
 	if (p->mode() == Widget::Select) {
@@ -90,9 +94,7 @@ AuxElement::AuxElement( QStringList inchannel, QStringList outchannel, MixingMat
 		_layout->addWidget(disp_name, 0);
 	}
 	
-	_poti = new JackMix::GUI::Knob(
-		amptodb( backend()->getVolume( _in[0], _out[0] ) ),
-		dbmin, dbmax, 2, 3, this );
+	_poti = new JackMix::GUI::Knob(amptodb( backend()->getVolume( _in[0], _out[0] ) ),dbmin, dbmax, 2, 3, this );
 	_layout->addWidget( _poti, 100 );
 
 	connect( _poti, SIGNAL( valueChanged( double ) ), this, SLOT( emitvalue( double ) ) );
@@ -120,3 +122,49 @@ void AuxElement::emitvalue( double n ) {
 }
 
 void AuxElement::setIndicator(const QColor& c) { _poti->setIndicatorColor(c); };
+
+AuxElementSlider::AuxElementSlider( QStringList inchannel, QStringList outchannel, MixingMatrix::Widget* p, const char* n )
+	: Element( inchannel, outchannel, p, "AuxElementSlider", n )
+	, dB2VolCalc( -42, 6 )
+{
+	if (p->mode() == Widget::Select) {
+		menu()->addAction( "Select", this, SLOT( slot_simple_select() ) );
+		menu()->addAction( "Replace", this, SLOT( slot_simple_replace() ) );
+	}
+	menu()->addAction( "Assign MIDI Parameter", this, SLOT( slot_assign_midi_parameters() ) );
+
+	QVBoxLayout* _layout = new QVBoxLayout( this );
+
+	if ( _in[0] == _out[0] ) {
+		disp_name = new QLabel( QString( "<qt><center>%1</center></qt>" ).arg( _in[0] ), this );
+		_layout->addWidget(disp_name, 0);
+	}
+	
+	_poti = new JackMix::GUI::Slider(amptodb( backend()->getVolume( _in[0], _out[0] ) ),dbmin, dbmax, 2, 3, this );
+	_layout->addWidget( _poti, 100 );
+
+	connect( _poti, SIGNAL( valueChanged( double ) ), this, SLOT( emitvalue( double ) ) );
+	connect( _poti, SIGNAL( select() ), this, SLOT( slot_simple_select() ) );
+	connect( _poti, SIGNAL( replace() ), this, SLOT( slot_simple_replace() ) );
+	
+	midi_params.append(0);        // Initial MIDI paramater number
+	midi_delegates.append(_poti); //   for the potentiometer
+	//qDebug()<<"There are "<<midi_delegates.size()<<" Midi delegates";
+
+	// Now construct the parameter setting menu
+	_cca = new JackMix::GUI::MidiControlChannelAssigner(QString("Set MIDI control parameter"),
+	                                                     "<qt>" + _in[0] + " &rarr; "  + _out[0] + "</qt>",
+	                                                     QStringList() << "Gain",
+	                                                     midi_params,
+		                                             this
+	                                                    );
+	connect( _cca, SIGNAL(assignParameters(QList<int>)), this, SLOT(update_midi_parameters(QList<int>)) );
+}
+AuxElementSlider::~AuxElementSlider() {
+}
+
+void AuxElementSlider::emitvalue( double n ) {
+	backend()->setVolume( _in[0], _out[0], dbtoamp( n ) );
+}
+
+//void AuxElementSlider::setIndicator(const QColor& c) { _poti->setIndicatorColor(c); };

--- a/libelements/aux_elements.cpp
+++ b/libelements/aux_elements.cpp
@@ -57,11 +57,11 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"AuxElement";
 	}
-	//state used to represent the type (0 = slider, 1 = knob)
-	//based on current type shown by the state value output should be the opposing type
-	QStringList canCreate( int in, int out, int state = 0 ) const {
-		if ( in==1 && out==1 && state==0) return QStringList()<<"AuxElement";
-		if ( in==1 && out==1 && state==1) return QStringList()<<"AuxElementSlider";
+	//ctrlType represens the type of the element that will be replaced with the new element
+	//ctrlType is defalut set to AuxElementSlider so an AuxElement will be the default output
+	QStringList canCreate( int in, int out, std::string ctrlType = "AuxElementSlider" ) const {
+		if ( in==1 && out==1 && ctrlType=="AuxElementSlider") return QStringList()<<"AuxElement";
+		if ( in==1 && out==1 && ctrlType=="AuxElement") return QStringList()<<"AuxElementSlider";
 		return QStringList();
 	}
 

--- a/libelements/aux_elements.cpp
+++ b/libelements/aux_elements.cpp
@@ -57,6 +57,8 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"AuxElement";
 	}
+	//state used to represent the type (0 = slider, 1 = knob)
+	//based on current type shown by the state value output should be the opposing type
 	QStringList canCreate( int in, int out, int state = 0 ) const {
 		if ( in==1 && out==1 && state==0) return QStringList()<<"AuxElement";
 		if ( in==1 && out==1 && state==1) return QStringList()<<"AuxElementSlider";

--- a/libelements/aux_elements.h
+++ b/libelements/aux_elements.h
@@ -34,10 +34,14 @@ namespace JackMix {
 
 namespace GUI {
 	class Knob;
+    class Slider;
 	class MidiControlChannelAssigner;
 }
 
 namespace MixerElements {
+
+class AuxElement;
+class AuxElementSlider;
 	
 /**
  * Simpliest form of a control connecting one input with one output.
@@ -59,6 +63,25 @@ public slots:
 
 private:
 	JackMix::GUI::Knob *_poti;
+};
+
+class AuxElementSlider : public JackMix::MixingMatrix::Element
+                 , public dB2VolCalc {
+Q_OBJECT
+public:
+	AuxElementSlider( QStringList inchannel, QStringList outchannel, MixingMatrix::Widget*, const char* =0 );
+	~AuxElementSlider();
+
+	int inchannels() const { return 1; }
+	int outchannels() const { return 1; }
+	
+	void setIndicator(const QColor& c);
+ 
+public slots:
+	void emitvalue( double );
+
+private:
+	JackMix::GUI::Slider *_poti;
 };
 
 void init_aux_elements();

--- a/libelements/stereo_elements.cpp
+++ b/libelements/stereo_elements.cpp
@@ -51,7 +51,7 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"Mono2StereoElement"<<"Stereo2StereoElement";
 	}
-	QStringList canCreate( int in, int out ) const {
+	QStringList canCreate( int in, int out, int state = 0 ) const {
 		if ( in==1 && out==2 ) return QStringList()<<"Mono2StereoElement";
 		if ( in==2 && out==2 ) return QStringList()<<"Stereo2StereoElement";
 		return QStringList();
@@ -72,7 +72,7 @@ void MixerElements::init_stereo_elements() {
 
 
 Mono2StereoElement::Mono2StereoElement( QStringList inchannel, QStringList outchannels, MixingMatrix::Widget* p, const char* n )
-	: Element( inchannel, outchannels, p, n )
+	: Element( inchannel, outchannels, p, "Mono2StereoElement", n)
 	, dB2VolCalc( -42, 6 )
 	, _balance_value( 0 )
 	, _volume_value( 0 )
@@ -162,7 +162,7 @@ void Mono2StereoElement::calculateVolumes() {
 
 
 Stereo2StereoElement::Stereo2StereoElement( QStringList inchannels, QStringList outchannels, MixingMatrix::Widget* p, const char* n )
-	: Element( inchannels, outchannels, p, n )
+	: Element( inchannels, outchannels, p,"Stereo2StereoElement", n )
 	, dB2VolCalc( -42, 6 )
 	, _balance_value( 0 )
 	, _volume_value( 0 )

--- a/libelements/stereo_elements.cpp
+++ b/libelements/stereo_elements.cpp
@@ -51,6 +51,7 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"Mono2StereoElement"<<"Stereo2StereoElement";
 	}
+	//state unused
 	QStringList canCreate( int in, int out, int state = 0 ) const {
 		if ( in==1 && out==2 ) return QStringList()<<"Mono2StereoElement";
 		if ( in==2 && out==2 ) return QStringList()<<"Stereo2StereoElement";

--- a/libelements/stereo_elements.cpp
+++ b/libelements/stereo_elements.cpp
@@ -51,8 +51,8 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"Mono2StereoElement"<<"Stereo2StereoElement";
 	}
-	//state unused
-	QStringList canCreate( int in, int out, int state = 0 ) const {
+	//ctrlType unused
+	QStringList canCreate( int in, int out, std::string ctrlType = "AuxElementSlider" ) const {
 		if ( in==1 && out==2 ) return QStringList()<<"Mono2StereoElement";
 		if ( in==2 && out==2 ) return QStringList()<<"Stereo2StereoElement";
 		return QStringList();

--- a/libmatrix/mixingmatrix.cpp
+++ b/libmatrix/mixingmatrix.cpp
@@ -92,12 +92,8 @@ void Widget::replace( Element* n ) {
 	//qDebug( "Widget::replace( Element* %p )", n );
 	//qDebug( "This Element has %i selected neighbors.", n->neighbors() );
 	//qDebug( " and %i selected followers.", n->followers( n->neighbors() ) );
-	//state used to represent the type (0 = slider, 1 = knob)
-	//state defaults to 0 so it will default to creating an AuxElement
-	int state = 0;
-	if (n->_type =="AuxElement"){
-		state=1;
-	}
+	//ctrlType used to represent the type of the element
+	std::string ctrlType = n->_type;
 
 	QStringList in, out;
 	in = n->neighborsList();
@@ -112,7 +108,7 @@ void Widget::replace( Element* n ) {
 				tmp->deleteLater();
 		}
 	}
-	createControl( in, out, state );
+	createControl( in, out, ctrlType );
 	QTimer::singleShot( 1, this, SLOT( autoFill() ) );
 }
 
@@ -131,10 +127,10 @@ Element* Widget::getResponsible( QString in, QString out ) const {
 	return 0;
 }
 
-bool Widget::createControl( QStringList inchannels, QStringList outchannels, int state) {
+bool Widget::createControl( QStringList inchannels, QStringList outchannels, std::string ctrlType) {
 	//qDebug( "Widget::createControl( QStringList '%s', QStringList '%s', %s)", qPrintable( inchannels.join( "," ) ), qPrintable( outchannels.join( "," ) ) );
 
-	QStringList controls = Global::the()->canCreate( inchannels.size(), outchannels.size(), state );
+	QStringList controls = Global::the()->canCreate( inchannels.size(), outchannels.size(), ctrlType );
 	if ( ! controls.isEmpty() ) {
 		//qDebug( "Found %s to control [%i,%i] channels", controls.front().toStdString().c_str(), inchannels.size(), outchannels.size() );
 		return Global::the()->create( controls.front(), inchannels, outchannels, this );
@@ -535,11 +531,11 @@ void Global::unregisterFactory( ElementFactory* n ) {
 	_factories.removeAll( n );
 }
 
-QStringList Global::canCreate( int in, int out, int state) {
+QStringList Global::canCreate( int in, int out, std::string ctrlType) {
 	//qDebug() << "Global::canCreate(" << in << "," << out << ")";
 	QStringList tmp;
 	for ( int i=0; i<_factories.size(); i++ )
-		tmp += _factories[ i ]->canCreate( in, out, state );
+		tmp += _factories[ i ]->canCreate( in, out, ctrlType );
 	//qDebug() << " returning" << tmp;
 	return tmp;
 }

--- a/libmatrix/mixingmatrix.cpp
+++ b/libmatrix/mixingmatrix.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "mixingmatrix.h"
+
 #include "mixingmatrix_privat.h"
 #include "mixingmatrix.moc"
 #include "mixingmatrix_privat.moc"
@@ -42,6 +43,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QList>
 #include <QtGui/QColor>
+#include <string>
 
 namespace JackMix {
 namespace MixingMatrix {
@@ -90,6 +92,12 @@ void Widget::replace( Element* n ) {
 	//qDebug( "Widget::replace( Element* %p )", n );
 	//qDebug( "This Element has %i selected neighbors.", n->neighbors() );
 	//qDebug( " and %i selected followers.", n->followers( n->neighbors() ) );
+	int s = 0;
+	std::string t = typeid(n).name();
+	if (n->_type =="AuxElement"){
+		s=1;
+	}
+
 	QStringList in, out;
 	in = n->neighborsList();
 	//qDebug( "Selected ins = %s", qPrintable( in.join( "," ) ) );
@@ -103,7 +111,7 @@ void Widget::replace( Element* n ) {
 				tmp->deleteLater();
 		}
 	}
-	createControl( in, out );
+	createControl( in, out, s );
 	QTimer::singleShot( 1, this, SLOT( autoFill() ) );
 }
 
@@ -122,10 +130,10 @@ Element* Widget::getResponsible( QString in, QString out ) const {
 	return 0;
 }
 
-bool Widget::createControl( QStringList inchannels, QStringList outchannels ) {
+bool Widget::createControl( QStringList inchannels, QStringList outchannels, int state) {
 	//qDebug( "Widget::createControl( QStringList '%s', QStringList '%s', %s)", qPrintable( inchannels.join( "," ) ), qPrintable( outchannels.join( "," ) ) );
 
-	QStringList controls = Global::the()->canCreate( inchannels.size(), outchannels.size() );
+	QStringList controls = Global::the()->canCreate( inchannels.size(), outchannels.size(), state );
 	if ( ! controls.isEmpty() ) {
 		//qDebug( "Found %s to control [%i,%i] channels", controls.front().toStdString().c_str(), inchannels.size(), outchannels.size() );
 		return Global::the()->create( controls.front(), inchannels, outchannels, this );
@@ -359,7 +367,7 @@ void Widget::debugPrint() {
 }
 
 
-Element::Element( QStringList in, QStringList out, Widget* p, const char* n )
+Element::Element( QStringList in, QStringList out, Widget* p, std::string t, const char* n)
 	: QFrame( p )
 	, _menu( new QMenu( this ) )
 	, _cca( 0 )
@@ -367,6 +375,7 @@ Element::Element( QStringList in, QStringList out, Widget* p, const char* n )
 	, _out( out )
 	, _selected( false )
 	, _parent( p )
+	, _type(t)
 {
 	//qDebug( "MixingMatrix::Element::Element( QStringList '%s', QStringList '%s' )", qPrintable( in.join(",") ), qPrintable( out.join(",") ) );
 	disp_name = 0; // Assumme no label for this element for now
@@ -525,11 +534,11 @@ void Global::unregisterFactory( ElementFactory* n ) {
 	_factories.removeAll( n );
 }
 
-QStringList Global::canCreate( int in, int out ) {
+QStringList Global::canCreate( int in, int out, int state) {
 	//qDebug() << "Global::canCreate(" << in << "," << out << ")";
 	QStringList tmp;
 	for ( int i=0; i<_factories.size(); i++ )
-		tmp += _factories[ i ]->canCreate( in, out );
+		tmp += _factories[ i ]->canCreate( in, out, state );
 	//qDebug() << " returning" << tmp;
 	return tmp;
 }

--- a/libmatrix/mixingmatrix.cpp
+++ b/libmatrix/mixingmatrix.cpp
@@ -92,10 +92,11 @@ void Widget::replace( Element* n ) {
 	//qDebug( "Widget::replace( Element* %p )", n );
 	//qDebug( "This Element has %i selected neighbors.", n->neighbors() );
 	//qDebug( " and %i selected followers.", n->followers( n->neighbors() ) );
-	int s = 0;
-	std::string t = typeid(n).name();
+	//state used to represent the type (0 = slider, 1 = knob)
+	//state defaults to 0 so it will default to creating an AuxElement
+	int state = 0;
 	if (n->_type =="AuxElement"){
-		s=1;
+		state=1;
 	}
 
 	QStringList in, out;
@@ -111,7 +112,7 @@ void Widget::replace( Element* n ) {
 				tmp->deleteLater();
 		}
 	}
-	createControl( in, out, s );
+	createControl( in, out, state );
 	QTimer::singleShot( 1, this, SLOT( autoFill() ) );
 }
 

--- a/libmatrix/mixingmatrix.h
+++ b/libmatrix/mixingmatrix.h
@@ -84,8 +84,8 @@ public:
 	
 	/// Create Controls
 	// Create controls. return true on success
-	//takes a list of the input and output channels as well as state used to represent the type (0 = slider, 1 = knob)
-	bool createControl( QStringList inchannels, QStringList outchannels, int state = 0);
+	//takes a list of the input and output channels as well as ctrlType the type of the element currently in use
+	bool createControl( QStringList inchannels, QStringList outchannels, std::string ctrlType = "AuxElementSlider");
 
 	/// Layout
 	QSize smallestElement() const;
@@ -188,7 +188,7 @@ public:
 
 	/**
 	 * Do the things you need to do in the subclasses when the
-	 * selected state changes.
+	 * selected ctrlType changes.
 	 */
 	virtual void isSelected( bool ) {};
 
@@ -299,7 +299,7 @@ public:
 	 * Returns a list of the elements this factory can create and
 	 * which support the named number of in and out channels
 	 */
-	virtual QStringList canCreate( int in, int out,int state = 0 ) const =0;
+	virtual QStringList canCreate( int in, int out,std::string ctrlType = "AuxElementSlider" ) const =0;
 
 	/**
 	 * Returns an object of the given Elementtype or 0 if this factory can not create it.

--- a/libmatrix/mixingmatrix.h
+++ b/libmatrix/mixingmatrix.h
@@ -84,6 +84,7 @@ public:
 	
 	/// Create Controls
 	// Create controls. return true on success
+	//takes a list of the input and output channels as well as state used to represent the type (0 = slider, 1 = knob)
 	bool createControl( QStringList inchannels, QStringList outchannels, int state = 0);
 
 	/// Layout

--- a/libmatrix/mixingmatrix.h
+++ b/libmatrix/mixingmatrix.h
@@ -84,7 +84,7 @@ public:
 	
 	/// Create Controls
 	// Create controls. return true on success
-	bool createControl( QStringList inchannels, QStringList outchannels);
+	bool createControl( QStringList inchannels, QStringList outchannels, int state = 0);
 
 	/// Layout
 	QSize smallestElement() const;
@@ -159,11 +159,12 @@ Q_PROPERTY( int ins READ inchannels )
 Q_PROPERTY( int outs READ outchannels )
 Q_PROPERTY( QString name READ name WRITE name )
 public:
+
 	/**
 	 * Gets the upper left corner in channelnames.
 	 * And lists with the names of the channels to control.
 	 */
-	Element( QStringList in, QStringList out, Widget*, const char* =0 );
+	Element( QStringList in, QStringList out, Widget*, std::string t, const char* =0);
 	virtual ~Element();
 
 	JackMix::BackendInterface* backend() const { return _parent->backend(); }
@@ -278,6 +279,9 @@ private slots:
 private:
 	bool _selected;
 	Widget* _parent;
+public:
+	std::string _type;
+	
 };
 
 
@@ -294,7 +298,7 @@ public:
 	 * Returns a list of the elements this factory can create and
 	 * which support the named number of in and out channels
 	 */
-	virtual QStringList canCreate( int in, int out ) const =0;
+	virtual QStringList canCreate( int in, int out,int state = 0 ) const =0;
 
 	/**
 	 * Returns an object of the given Elementtype or 0 if this factory can not create it.

--- a/libmatrix/mixingmatrix_privat.h
+++ b/libmatrix/mixingmatrix_privat.h
@@ -49,7 +49,7 @@ public:
 	 * Returns the names of the Controls for the given number of in
 	 * and out channels
 	 */
-	QStringList canCreate( int in, int out, int state = 0 );
+	QStringList canCreate( int in, int out, std::string ctrlType = "AuxElementSlider" );
 
 	/**
 	 * Create a control of the given type and for the given in and

--- a/libmatrix/mixingmatrix_privat.h
+++ b/libmatrix/mixingmatrix_privat.h
@@ -49,7 +49,7 @@ public:
 	 * Returns the names of the Controls for the given number of in
 	 * and out channels
 	 */
-	QStringList canCreate( int in, int out );
+	QStringList canCreate( int in, int out, int state = 0 );
 
 	/**
 	 * Create a control of the given type and for the given in and


### PR DESCRIPTION
Adds a new slider element that can replace single knob elements.
This adds a type variable to the elements to identify them, the functionality can be used in further expansions to allow for more elements of the same dimension to be added and replacements dependent on current element type.