### PR TITLE
Fix typos

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,7 +2,7 @@ Installation
 ------------
 
 
-To install JackMix you basicly need to do:
+To install JackMix you basically need to do:
  scons
 
 JackMix requires Qt4.2 or higher, the jack-audio-connection-kit

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See:
 
 
 JackMix is a matrix mixer allowing p input channels to be mixed into
-q output channles by a matrix of faders. It relies on the Jack framework
+q output channels by a matrix of faders. It relies on the Jack framework
 to route these inputs and outputs.
 
 There's a video about Nick using jackmix at [https://vimeo.com/75655401]

--- a/TODO
+++ b/TODO
@@ -2,7 +2,7 @@
 
   - currently compiles, builds and runs OK on my machine (nick)
 
-* Make matix components pretty
+* Make matrix components pretty
 
   - proper group buttons, better adjust buttons...
     I can't remember the key bindings, how can I expect the

--- a/admin/pkgconfig.py
+++ b/admin/pkgconfig.py
@@ -30,7 +30,7 @@ def CheckForPKGConfig( context, version='0.0.0' ):
         return ret
 
 #
-# Checks for the existance of the package and returns the packages flags.
+# Checks for the existence of the package and returns the packages flags.
 #
 # This should allow caching of the flags so that pkg-config is called only once.
 #

--- a/jackmix/mainwindow.cpp
+++ b/jackmix/mainwindow.cpp
@@ -211,7 +211,7 @@ void MainWindow::init() {
 	connect (_backend, SIGNAL(outputLevelsChanged(JackMix::BackendInterface::levels_t)),
                  _outputswidget, SLOT(update_peak_inidicators(JackMix::BackendInterface::levels_t)));
 
-	// Connect the backend's MIDI control events to the MIDI listener's despatcher.
+	// Connect the backend's MIDI control events to the MIDI listener's dispatcher.
 	connect (_backend, SIGNAL(cc_message(int, int)),
 		 midiControlSender, SLOT(despatch_message(int, int)));
 
@@ -379,7 +379,7 @@ void MainWindow::saveFile( QString path ) {
 		//qDebug()<<" Responsible element for " << in << ": " << _inputswidget->getResponsible(in, in);
 		const QList<int> &mp = _inputswidget->getResponsible(in,in)->midiParameters();
 		// I'm going to use a loop to make it clear ordering is important
-		// (actually, foreach maitains ordering of a QList in Qt 4.8, but this might change
+		// (actually, foreach maintains ordering of a QList in Qt 4.8, but this might change
 		QStringList mpl;
 		for (int i = 0 ; i < mp.size() ; i++ )
 			mpl << QString("%1").arg(mp.at(i));
@@ -420,7 +420,7 @@ void MainWindow::saveFile( QString path ) {
 		foreach( QString out, outs ) {
 			Element* tmp = _mixerwidget->getResponsible( in, out );
 			if ( !savedelements.contains( tmp ) && ( tmp->in().size() > 1 || tmp->out().size() > 1 ) ) {
-				// Save all the midi conotrol parameters for this compound element
+				// Save all the midi control parameters for this compound element
 				xml += "<element midi=\"";
 				const QList<int> &mp = tmp->midiParameters();
 				QStringList mpl;

--- a/libcontrol/controlsender.cpp
+++ b/libcontrol/controlsender.cpp
@@ -53,7 +53,7 @@ void PortListener::run()
 	running = true;
 	
 	while (running) {
-		// *ix system calls are uninterruptable, so we'll pop back into
+		// *ix system calls are uninterruptible, so we'll pop back into
 		// user-space every 200ms or so
 		if (poll(pfd, npfd, 200) > 0) {
 			do {
@@ -99,7 +99,7 @@ ControlSender::ControlSender(const char* port_name)
 }
 
 ControlSender::~ControlSender() {
-	// close down the port listner thread
+	// close down the port listener thread
 	port_listener->quit();
 	port_listener->wait();
 	// then close the MIDI port
@@ -124,12 +124,12 @@ void ControlSender::unsubscribe(ControlReceiver *receiver) {
 		unsubscribe(receiver, i);
 }
 void ControlSender::unsubscribe(ControlReceiver *receiver, int parameter) {
-	if (parameter > 0 && parameter < maxMidiParam)  // remove all occurances from this routing entry
+	if (parameter > 0 && parameter < maxMidiParam)  // remove all occurrences from this routing entry
 		dtab[parameter].removeAll(receiver);
 }
 
 void ControlSender::despatch_message(int param, int val) {
-	// Ignore parameter index past end of the despatch table.
+	// Ignore parameter index past end of the dispatch table.
 	// That includes the "specials" like MIDI all-off, which, it turns out,
 	// is one of the reserved CC messages referred to as Channel Control messages
 	// (controller # >= 122) See for example:

--- a/libcontrol/controlsender.h
+++ b/libcontrol/controlsender.h
@@ -22,7 +22,7 @@
 #ifndef CONTROLSENDER_H
 #define CONTROLSENDER_H
 
-/** ControlSender Create and Service incomming MIDI control sequences
+/** ControlSender Create and Service incoming MIDI control sequences
  * 
  * An application should have one instance of this class for each MIDI port
  * which is requires monitoring (so jackmix has only one). The lifecycle
@@ -96,7 +96,7 @@ protected:
 	int port_id;
 	snd_seq_t *seq_handle;
 	static constexpr int maxMidiParam = 120;
-	/** Despatch table
+	/** Dispatch table
 	 *  An array of vectors, one for each MIDI parameter read from the input
 	 *  channel.
 	 */
@@ -123,9 +123,9 @@ public:
 	void quit(void) { running = false; };
 
 signals:
-	/** emit incomming MIDI messages
-	 * @param param  Parameter of the incomming control message
-	 * @param val Value of the incomming message
+	/** emit incoming MIDI messages
+	 * @param param  Parameter of the incoming control message
+	 * @param val Value of the incoming message
 	 */
 	void message(int param, int val);
 

--- a/libcore/backend_interface.h
+++ b/libcore/backend_interface.h
@@ -67,14 +67,14 @@ Q_OBJECT
 		/**
 		 * @brief Add a channel and return true on success.
 		 *
-		 * If the actual backend doesn't support adding and removing, thats
+		 * If the actual backend doesn't support adding and removing, that's
 		 * okay. Just return false..
 		 */
 		virtual bool addOutput( QString ) =0;
 		/**
 		 * @brief Add a channel and return true on success.
 		 *
-		 * If the actual backend doesn't support adding and removing, thats
+		 * If the actual backend doesn't support adding and removing, that's
 		 * okay. Just return false..
 		 */
 		virtual bool addInput(QString name) =0;
@@ -95,14 +95,14 @@ Q_OBJECT
 		/**
 		 * @brief Remove a channel and return true on success.
 		 *
-		 * If the actual backend doesn't support adding and removing, thats
+		 * If the actual backend doesn't support adding and removing, that's
 		 * okay. Just return false..
 		 */
 		virtual bool removeOutput( QString ) =0;
 		/**
 		 * @brief Remove a channel and return true on success.
 		 *
-		 * If the actual backend doesn't support adding and removing, thats
+		 * If the actual backend doesn't support adding and removing, that's
 		 * okay. Just return false..
 		 */
 		virtual bool removeInput( QString ) =0;
@@ -113,14 +113,14 @@ Q_OBJECT
                 // that you can ignore it, and no signals will be sent; the input
                 // and output potentiometers remain dark
                 //
-                // If you would like to impelment it, the idea is to record the
+                // If you would like to implement it, the idea is to record the
                 // abs maximum level of each buffer (as floats in the range 0..1)
                 // newInputLevel(QString key, float max) and newOutputLevel will
                 // do that for you. When the levels for each input and output have
                 // been recorded, call report() to signal the Widget to change the
                 // colours of the input and output elements
 		//
-		// Similarly, of the backend of the dervied class uses its own
+		// Similarly, of the backend of the derived class uses its own
 		// MIDI message handler, it can use the cc_message signal to notify
 		// control changes.
                 
@@ -161,7 +161,7 @@ Q_OBJECT
 		
 		/** How long a fader change takes to execute (for de-zipping) */
 		constexpr static float interp_time {.08};
-		/** Fader iterpolation length in samples. It is initialised
+		/** Fader interpolation length in samples. It is initialised
 		 *  by the class implementing this interface based on the
 		 *  interp_time and the backend's sample rate, probably by
 		 *  calling the utility function set_interp_len
@@ -185,7 +185,7 @@ Q_OBJECT
 		struct FaderState {
 			float target;  /**< The target setting of the fader */
 			float current; /**< The current setting of the fader,
-				            changing troughout interpolation */
+				            changing throughout interpolation */
 			unsigned int num_steps; /**< The number of steps required
 			                             to interpolate this fader change */
 			unsigned int cur_step;  /**< Count of steps in this interpolation */
@@ -209,7 +209,7 @@ Q_OBJECT
 			FaderState& operator=(float volume);
 			
 			/**
-			 * Qt types (particuarly qHash, qMap) need a default constructor
+			 * Qt types (particularly qHash, qMap) need a default constructor
 			 * because they don't have copy constructors. See:
 			 *  https://doc.qt.io/qt-5/qobject.html#no-copy-constructor-or-assignment-operator
 			 * So we have to supply one for FaderState so it plays nice with
@@ -235,7 +235,7 @@ Q_OBJECT
 		 * 
 		 * This assumes samples are stored in a buffer which can be
 		 * subscripted via [] and that they are all multiplied
-		 * by a constant which changes continuously througout
+		 * by a constant which changes continuously throughout
 		 * the length of the buffer. If that isn't true for the
 		 * backend implementing this interface, it will have
 		 * to provide its own code. You can't have virtual

--- a/libcore/updatefilter.h
+++ b/libcore/updatefilter.h
@@ -39,7 +39,7 @@
  *    infinite loop is born.
  * <dt>The <b>REAL</b> Solution:<dd>
  *    Plug the UpdateFilter between the server-connection and the slider.
- *    Everytime the server sends updates the filter will block the signals
+ *    Every time the server sends updates the filter will block the signals
  *    from the inside.
  * </dl>
  *

--- a/libelements/aux_elements.cpp
+++ b/libelements/aux_elements.cpp
@@ -57,8 +57,8 @@ public:
 	QStringList canCreate() const {
 		return QStringList()<<"AuxElement";
 	}
-	//ctrlType represens the type of the element that will be replaced with the new element
-	//ctrlType is defalut set to AuxElementSlider so an AuxElement will be the default output
+	//ctrlType represents the type of the element that will be replaced with the new element
+	//ctrlType is default set to AuxElementSlider so an AuxElement will be the default output
 	QStringList canCreate( int in, int out, std::string ctrlType = "AuxElementSlider" ) const {
 		if ( in==1 && out==1 && ctrlType=="AuxElementSlider") return QStringList()<<"AuxElement";
 		if ( in==1 && out==1 && ctrlType=="AuxElement") return QStringList()<<"AuxElementSlider";
@@ -103,7 +103,7 @@ AuxElement::AuxElement( QStringList inchannel, QStringList outchannel, MixingMat
 	connect( _poti, SIGNAL( select() ), this, SLOT( slot_simple_select() ) );
 	connect( _poti, SIGNAL( replace() ), this, SLOT( slot_simple_replace() ) );
 	
-	midi_params.append(0);        // Initial MIDI paramater number
+	midi_params.append(0);        // Initial MIDI parameter number
 	midi_delegates.append(_poti); //   for the potentiometer
 	//qDebug()<<"There are "<<midi_delegates.size()<<" Midi delegates";
 
@@ -149,7 +149,7 @@ AuxElementSlider::AuxElementSlider( QStringList inchannel, QStringList outchanne
 	connect( _poti, SIGNAL( select() ), this, SLOT( slot_simple_select() ) );
 	connect( _poti, SIGNAL( replace() ), this, SLOT( slot_simple_replace() ) );
 	
-	midi_params.append(0);        // Initial MIDI paramater number
+	midi_params.append(0);        // Initial MIDI parameter number
 	midi_delegates.append(_poti); //   for the potentiometer
 	//qDebug()<<"There are "<<midi_delegates.size()<<" Midi delegates";
 

--- a/libelements/aux_elements.h
+++ b/libelements/aux_elements.h
@@ -44,7 +44,7 @@ class AuxElement;
 class AuxElementSlider;
 	
 /**
- * Simpliest form of a control connecting one input with one output.
+ * Simplest form of a control connecting one input with one output.
  */
 class AuxElement : public JackMix::MixingMatrix::Element
                  , public dB2VolCalc {

--- a/libelements/stereo_elements.cpp
+++ b/libelements/stereo_elements.cpp
@@ -111,7 +111,7 @@ Mono2StereoElement::Mono2StereoElement( QStringList inchannel, QStringList outch
 	connect( _volume, SIGNAL( replace() ), this, SLOT( slot_simple_replace() ) );
 
 	// WATCH OUT: Order of initialisation is really important!
-	// Make sure all the widgets are contructed before adding them to the delegates list
+	// Make sure all the widgets are constructed before adding them to the delegates list
 
 	// Initial MIDI parameters and associated AbstractSliders
 	midi_params.append(0);
@@ -208,7 +208,7 @@ Stereo2StereoElement::Stereo2StereoElement( QStringList inchannels, QStringList 
 	menu()->addAction( assign );
 	
 	// WATCH OUT: Order of initialisation is really important!
-	// Make sure all the widgets are contructed before adding them to the delegates list
+	// Make sure all the widgets are constructed before adding them to the delegates list
 
 	// Initial MIDI parameters and associated AbstractSliders
 	midi_params.append(0);

--- a/libgui/abstractslider.cpp
+++ b/libgui/abstractslider.cpp
@@ -57,7 +57,7 @@ void AbstractSlider::setNormalisedValue(double v, bool show_numeric) {
 	v = qMax(v, 0.0);
 	v = qMin(v, 1.0);
 	// The call below will be handled by a virtual method in a derived class
-	// The second argument enables or suppresses an auxilliary numeric display
+	// The second argument enables or suppresses an auxiliary numeric display
 	// of the slider's value.
 	value(dbmin + v*(dbmax-dbmin), show_numeric);
 }
@@ -66,7 +66,7 @@ void AbstractSlider::setMidiValue(int iv) {
 	iv = qMax(iv, 0);
 	iv = qMin(iv, 127);
 	// Some cheap MIDI controllers "dither" (change randomly by 1 or more LSBs)
-	// so we'll suppress any auxilliary display of slider value because it might
+	// so we'll suppress any auxiliary display of slider value because it might
 	// keep popping up annoyingly when the slider isn't being adjusted.
 	setNormalisedValue(iv/127.0, false);
 }

--- a/libgui/abstractslider.h
+++ b/libgui/abstractslider.h
@@ -42,7 +42,7 @@ public:
 
 public slots:
 	virtual void value(double);
-	// Abstract class has no timed auxilliary displays, so ignore second argument if supplied
+	// Abstract class has no timed auxiliary displays, so ignore second argument if supplied
 	virtual void value(double n, bool) { value(n); };
 	double value() const { return _value; };
 	virtual void setNormalisedValue(double, bool show_numeric=true); //<! Set the slider position in the range (0.0, 1.0)

--- a/libgui/midicontrolchannelassigner.h
+++ b/libgui/midicontrolchannelassigner.h
@@ -42,13 +42,13 @@ class MidiControlChannelAssigner : public QDialog
 {
 Q_OBJECT
 public:
-	/** Contstructor
-	 *  Build a dialoge with the given title and label, and with the initial values supplied
+	/** Constructor
+	 *  Build a dialog with the given title and label, and with the initial values supplied
 	 *  as a list of integers. Midi supports control channels in the range 0-119;
 	 *  120 and above are reserved for "Channel Mode Messages"
 	 *  (see http://www.midi.org/techspecs/midimessages.php). If the pointer supplied in init
 	 *  is not null, it is assumed to reference an array of int large enough to hold one initial
-	 *  value for each requested conotrol channel.
+	 *  value for each requested control channel.
 	 * 
 	 *  The controls parameter is a list of strings which identify to the user the slider within
 	 *  the element being controlled, so a Mono-to-Stereo element may request a MIDI channel to

--- a/libmatrix/mixingmatrix.cpp
+++ b/libmatrix/mixingmatrix.cpp
@@ -151,7 +151,7 @@ void Widget::autoFill() {
 					createControl( QStringList()<<*init, QStringList()<<*outit );
 				// }
 				//else
-					//qDebug( "   (%s|%s) is allready occupied. :(", qPrintable( *init ), qPrintable( *outit ) );
+					//qDebug( "   (%s|%s) is already occupied. :(", qPrintable( *init ), qPrintable( *outit ) );
 			}
 	} else if ( _direction == Vertical ) {
 		//qDebug() << "Available outputs are" << _outchannels.join( "," );
@@ -397,7 +397,7 @@ Element::Element( QStringList in, QStringList out, Widget* p, std::string t, con
 	, _type(t)
 {
 	//qDebug( "MixingMatrix::Element::Element( QStringList '%s', QStringList '%s' )", qPrintable( in.join(",") ), qPrintable( out.join(",") ) );
-	disp_name = 0; // Assumme no label for this element for now
+	disp_name = 0; // Assume no label for this element for now
 	setFrameStyle( QFrame::Raised|QFrame::Panel );
 	setLineWidth( 1 );
 	if (p) p->anotherControl();

--- a/libmatrix/mixingmatrix.h
+++ b/libmatrix/mixingmatrix.h
@@ -180,7 +180,7 @@ public:
 	QStringList in() const { return _in; }
 	QStringList out() const { return _out; }
 
-	// Returns wether the control is responsible for the named node.
+	// Returns whether the control is responsible for the named node.
 	bool isResponsible( QString in, QString out );
 
 	bool isSelected() const { return _selected; }
@@ -209,7 +209,7 @@ public:
 	 *  on destruction (otherwise there may be a segfault at closedown)
 	 */
 	void invalidateRegistry() { _parent = 0; };
-	/** Replace all occurances of the old channel name with the new one in both the
+	/** Replace all occurrences of the old channel name with the new one in both the
 	 *  input and output channel lists
 	 */
 	void renamechannels(QString old_name, QString new_name);
@@ -243,7 +243,7 @@ protected:
 	 */
 	/** The current parameter associated with each delegate. */
 	QLayout* layout();
-	/** If the derrived class has a label, this is it.
+	/** If the derived class has a label, this is it.
 	 *  Used to change text if an input or output channel is renamed
 	 */
 	QLabel* disp_name;

--- a/libqlash/qlash.h
+++ b/libqlash/qlash.h
@@ -95,7 +95,7 @@ class qLashClient : public QObject
 
 	signals:
 		/**
-		 * @brief The server tells us to quit immediatly.
+		 * @brief The server tells us to quit immediately.
 		 *
 		 * ...without saving or user interaction ( if possible, otherwise
 		 * handling of lash-sessions gets very painful ).


### PR DESCRIPTION
Found via `codespell -q 3 -L childs`